### PR TITLE
chore: spring-security 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'mysql:mysql-connector-java'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
 }


### PR DESCRIPTION
- 보안을 위해 로그인을 요구하는 점과 개발 중 spring security 의 필요성을 느끼지 못하는 점에서 제거하기로 결정